### PR TITLE
Add endpoint for deleting skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .pytest_cache/
 __pycache__
 .vscode
+
+# Pycharm specific ignores
+.idea

--- a/app.py
+++ b/app.py
@@ -332,3 +332,12 @@ def user_information():
         return jsonify(data["user_information"]), 201
 
     return jsonify({"error": "Nothing changed"}), 400
+
+
+@app.route('/resume/skill', methods=['DELETE'])
+def delete_skill():
+    '''
+    Handles Skill deletion requests
+    '''
+
+    return jsonify({}), 200

--- a/app.py
+++ b/app.py
@@ -334,10 +334,14 @@ def user_information():
     return jsonify({"error": "Nothing changed"}), 400
 
 
-@app.route('/resume/skill', methods=['DELETE'])
-def delete_skill():
+@app.route('/resume/skill/<int:index>', methods=['DELETE'])
+def delete_skill(index):
     '''
     Handles Skill deletion requests
     '''
+    if not 0 <= index < len(data["skill"]):
+        return jsonify({"error": "Skill not found"}), 404
 
-    return jsonify({}), 200
+    data["skill"].pop(index)
+
+    return jsonify({"message": "Skill successfully deleted"}), 200

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -152,7 +152,7 @@ def test_delete_skill():
 
     # Delete the only skills.
     for _ in range(2):
-        response = app.test_client().delete(f'/resume/skill/0')
+        response = app.test_client().delete('/resume/skill/0')
         assert response.status_code == 200
         assert response.json["message"] == "Skill successfully deleted"
 

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -138,3 +138,26 @@ def test_invalid_phone_number():
     '''
     invalid_phone = "123456"
     assert validate_phone_number(invalid_phone) is False
+
+
+def test_delete_skill():
+    '''
+    Test the skill deletion endpoint for skill ID bounds checking.
+    '''
+    # Test some invalid skill indices (only index 0 is valid initially).
+    for index in range(2, 5):
+        response = app.test_client().delete(f'/resume/skill/{index}')
+        assert response.status_code == 404
+        assert response.json["error"] == "Skill not found"
+
+    # Delete the only skills.
+    for _ in range(2):
+        response = app.test_client().delete(f'/resume/skill/0')
+        assert response.status_code == 200
+        assert response.json["message"] == "Skill successfully deleted"
+
+    # Now all skill indices should return Not Found.
+    for index in range(0, 4):
+        response = app.test_client().delete(f'/resume/skill/{index}')
+        assert response.status_code == 404
+        assert response.json["error"] == "Skill not found"


### PR DESCRIPTION
Closes #3.

Adds an endpoint to allow the user to delete skills by index. I chose to pass the skill index as a path parameter instead of as JSON data for the sake of simplicity. 