### PR TITLE
Add `PUT` endpoint for updating experience

### DIFF
--- a/app.py
+++ b/app.py
@@ -179,34 +179,11 @@ def experience_by_index(index):
         if not request_body:
             return jsonify({"error": "Request must be JSON or include form data"}), 400
 
-        required_fields = {
-            "title": str,
-            "company": str,
-            "start_date": str,
-            "end_date": str,
-            "description": str,
-        }
+        error = validate_fields(["title", "company", "start_date", "end_date", "description"],
+                                 request_body)
 
-        missing_fields = [
-            field for field in required_fields if field not in request_body
-        ]
-        invalid_fields = [
-            field
-            for field, field_type in required_fields.items()
-            if field in request_body and not isinstance(request_body[field], field_type)
-        ]
-
-        if missing_fields or invalid_fields:
-            response = {"error": ""}
-            if missing_fields:
-                response[
-                    "error"
-                ] += f"Missing required fields: {', '.join(missing_fields)}. "
-            if invalid_fields:
-                response[
-                    "error"
-                ] += f"Invalid field types: {', '.join(invalid_fields)}."
-            return jsonify(response), 400
+        if error:
+            return jsonify({"error": ", ".join(error) + " parameter(s) is required"}), 400
 
         logo_filename = DEFAULT_LOGO
         if "logo" in request.files:
@@ -225,7 +202,7 @@ def experience_by_index(index):
             logo_filename,
         )
 
-        return jsonify({"message": "Experience updated", "id": index}), 200
+        return jsonify({"message": "Experience updated", "id": index}), 204
     return jsonify({}), 400
 
 

--- a/app.py
+++ b/app.py
@@ -143,28 +143,90 @@ def experience():
     return jsonify({})
 
 
-@app.route("/resume/experience/<int:index>", methods=["GET"])
+@app.route("/resume/experience/<int:index>", methods=["GET", "PUT"])
 def experience_by_index(index):
     """
-    Handle experience requests by index.
+    - GET:
+        - Returns a specific experience entry if a valid `index` is provided.
+        - If the `index` is invalid, returns a 404 error.
     
-    Retrieves a specific experience entry from the `data["experience"]` list based on the index.
-    
-    If the index is valid (within the range of the experience list), it returns the corresponding
-    experience entry.
-    Otherwise, it returns a 404 error with a message indicating that the experience was not found.
-    
-    :param index: (int) The index of the experience entry to retrieve.
-    
-    :returns: 
-        - JSON response containing the experience entry if the index is valid.
-        - JSON response containing an error message if the index is out of range.
-        - HTTP status code 200 if successful, 404 if the experience is not found.
+    - PUT:
+        - Updates an existing experience entry.
+        - Validates the required fields 
+          (`title`, `company`, `start_date`, `end_date`, `description`)
+          and ensures they are present and of the correct type.
+        - If any fields are missing or invalid, returns a 400 error.
+        - Optionally accepts a `logo` file, which will be saved if it is a valid file.
+        - Returns a success message and the ID of the updated record.
+
+    :param index: (int) The index of the experience record to retrieve.
+
+    :returns: JSON response containing the experience data or error message, along with the HTTP
+    status code.
+
     :rtype: tuple
     """
-    if 0 <= len(data["experience"]) and index < len(data["experience"]):
-        return jsonify(data["experience"][index])
-    return jsonify({"error": "Experience not found"}), 404
+    if request.method == "GET":
+        if 0 <= len(data["experience"]) and index < len(data["experience"]):
+            return jsonify(data["experience"][index])
+        return jsonify({"error": "Experience not found"}), 404
+    if request.method == "PUT":
+        if request.content_type == "multipart/form-data":
+            request_body = request.form
+        else:
+            request_body = request.get_json()
+
+        if not request_body:
+            return jsonify({"error": "Request must be JSON or include form data"}), 400
+
+        required_fields = {
+            "title": str,
+            "company": str,
+            "start_date": str,
+            "end_date": str,
+            "description": str,
+        }
+
+        missing_fields = [
+            field for field in required_fields if field not in request_body
+        ]
+        invalid_fields = [
+            field
+            for field, field_type in required_fields.items()
+            if field in request_body and not isinstance(request_body[field], field_type)
+        ]
+
+        if missing_fields or invalid_fields:
+            response = {"error": ""}
+            if missing_fields:
+                response[
+                    "error"
+                ] += f"Missing required fields: {', '.join(missing_fields)}. "
+            if invalid_fields:
+                response[
+                    "error"
+                ] += f"Invalid field types: {', '.join(invalid_fields)}."
+            return jsonify(response), 400
+
+        logo_filename = DEFAULT_LOGO
+        if "logo" in request.files:
+            logo_file = request.files["logo"]
+            if logo_file and allowed_file(logo_file.filename):
+                filename = secure_filename(logo_file.filename)
+                logo_file.save(os.path.join(app.config["UPLOAD_FOLDER"], filename))
+                logo_filename = filename
+
+        data["experience"][index] = Experience(
+            request_body["title"],
+            request_body["company"],
+            request_body["start_date"],
+            request_body["end_date"],
+            request_body["description"],
+            logo_filename,
+        )
+
+        return jsonify({"message": "Experience updated", "id": index}), 200
+    return jsonify({}), 400
 
 
 @app.route("/resume/education", methods=["GET", "POST"])
@@ -293,20 +355,17 @@ def skill():
     Handles Skill requests
     """
     if request.method == 'GET':
+        skill_id = request.args.get('id')
+        if skill_id is None:
+            return jsonify([sk.__dict__ for sk in data["skill"]]), 200
         try:
-            skill_id = request.args.get('id')
-            if skill_id is not None:
-                skill_id = int(skill_id)
-                if 0 <= skill_id < len(data['skill']):
-                    return jsonify(data['skill'][skill_id]), 200
-                raise ValueError
-            else:
-              return jsonify([sk.__dict__ for sk in data["skill"]])
-        except:
+            skill_id = int(skill_id)
+        except ValueError:
             return jsonify({'error': 'Invalid request'}), 400
-         
-    if request.method == "POST":
+        if 0 <= skill_id < len(data['skill']):
+            return jsonify(data['skill'][skill_id]), 200
 
+    if request.method == "POST":
         if request.content_type == "multipart/form-data":
             request_body = request.form
         else:

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -163,7 +163,7 @@ def test_delete_skill():
         assert response.json["error"] == "Skill not found"
 
 
-def test_upade_experience():
+def test_upgrade_experience():
     '''
     Test the update experience endpoint for experience ID bounds checking.
     Updates the only experience and check if the update was successful.
@@ -184,5 +184,4 @@ def test_upade_experience():
         "logo": "default.jpg"
     }
     response = app.test_client().put('/resume/experience/0', json=new_example_experience)
-    assert response.status_code == 200
-    assert response.json["message"] == "Experience updated"
+    assert response.status_code == 204

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -161,3 +161,28 @@ def test_delete_skill():
         response = app.test_client().delete(f'/resume/skill/{index}')
         assert response.status_code == 404
         assert response.json["error"] == "Skill not found"
+
+
+def test_upade_experience():
+    '''
+    Test the update experience endpoint for experience ID bounds checking.
+    Updates the only experience and check if the update was successful.
+    Check if the previous experience is not found.
+    '''
+    # Test some invalid experience indices (only index 0 is valid initially).
+    for index in range(2, 5):
+        response = app.test_client().put(f'/resume/experience/{index}')
+        assert response.status_code == 400
+
+    # Update the only experience.
+    new_example_experience = {
+        "title": "Software Developer",
+        "company": "A Cooler Company",
+        "start_date": "October 2022",
+        "end_date": "Present",
+        "description": "Writing JavaScript Code",
+        "logo": "default.jpg"
+    }
+    response = app.test_client().put('/resume/experience/0', json=new_example_experience)
+    assert response.status_code == 200
+    assert response.json["message"] == "Experience updated"


### PR DESCRIPTION
Resolves #8 
**Description**:
- Added `PUT` `/resume/experience/{id}`:
  - Validates required fields (`title`, `company`, `start_date`, `end_date`, `description`).
  - Optionally handles `logo` file.
  - Returns 400 for missing/invalid fields.
  - On success, returns a message and updated record ID.

**Tests**:
- Added `test_update_experience` to verify:
  - Invalid experience IDs return 400.
  - Successful update of experience returns 200.