### PR TITLE
Add Custom Sections Feature for Resume Builder

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,8 +6,6 @@ import os
 import logging
 from werkzeug.utils import secure_filename
 from flask import Flask, jsonify, request, send_from_directory
-from models import Experience, Education, Skill
-from flask import Flask, jsonify, request
 from models import Experience, Education, Skill, UserInformation
 from helpers import validate_fields, validate_phone_number
 
@@ -50,18 +48,10 @@ def reset_data():
         ),
     ]
     data["skill"] = [
-        Skill(
-            "Python",
-            "1-2 Years",
-            "example-logo.png"
-        ),
+        Skill("Python", "1-2 Years", "example-logo.png"),
     ]
     data["user_information"] = [
-        UserInformation(
-            "Joe Smith",
-            "example@gmail.com",
-            "+11234567890"
-        ),
+        UserInformation("Joe Smith", "example@gmail.com", "+11234567890"),
     ]
 
 
@@ -75,10 +65,7 @@ def allowed_file(filename):
     :param filename: The name of the file to check
     :return: True if the file extension is allowed, False otherwise
     """
-    return (
-        "." in filename
-        and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
-    )
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
 
 
 def handle_missing_invalid_fields(request_body, required_fields):
@@ -89,9 +76,7 @@ def handle_missing_invalid_fields(request_body, required_fields):
     :param required_fields: A dictionary of field names and their expected types
     :return: A tuple (missing_fields, invalid_fields)
     """
-    missing_fields = [
-        field for field in required_fields if field not in request_body
-    ]
+    missing_fields = [field for field in required_fields if field not in request_body]
     invalid_fields = [
         field
         for field, field_type in required_fields.items()
@@ -127,7 +112,8 @@ def experience():
 
     if request.method == "POST":
         request_body = (
-            request.form if request.content_type == "multipart/form-data"
+            request.form
+            if request.content_type == "multipart/form-data"
             else request.get_json()
         )
         if not request_body:
@@ -145,10 +131,21 @@ def experience():
         )
 
         if missing_fields or invalid_fields:
-            logging.warning("Validation failed: Missing %s, Invalid %s",
-                            missing_fields, invalid_fields)
-            return jsonify({"error": "Validation failed", "missing_fields": missing_fields,
-                            "invalid_fields": invalid_fields}), 400
+            logging.warning(
+                "Validation failed: Missing %s, Invalid %s",
+                missing_fields,
+                invalid_fields,
+            )
+            return (
+                jsonify(
+                    {
+                        "error": "Validation failed",
+                        "missing_fields": missing_fields,
+                        "invalid_fields": invalid_fields,
+                    }
+                ),
+                400,
+            )
 
         # Handle logo file
         logo_filename = DEFAULT_LOGO
@@ -173,7 +170,10 @@ def experience():
         new_experience_id = len(data["experience"]) - 1
 
         logging.info("New experience added: %s", new_experience.title)
-        return jsonify({"message": "New experience created", "id": new_experience_id}), 201
+        return (
+            jsonify({"message": "New experience created", "id": new_experience_id}),
+            201,
+        )
 
     return jsonify({})
 
@@ -184,10 +184,10 @@ def experience_by_index(index):
     - GET:
         - Returns a specific experience entry if a valid `index` is provided.
         - If the `index` is invalid, returns a 404 error.
-    
+
     - PUT:
         - Updates an existing experience entry.
-        - Validates the required fields 
+        - Validates the required fields
           (`title`, `company`, `start_date`, `end_date`, `description`)
           and ensures they are present and of the correct type.
         - If any fields are missing or invalid, returns a 400 error.
@@ -214,11 +214,15 @@ def experience_by_index(index):
         if not request_body:
             return jsonify({"error": "Request must be JSON or include form data"}), 400
 
-        error = validate_fields(["title", "company", "start_date", "end_date", "description"],
-                                 request_body)
+        error = validate_fields(
+            ["title", "company", "start_date", "end_date", "description"], request_body
+        )
 
         if error:
-            return jsonify({"error": ", ".join(error) + " parameter(s) is required"}), 400
+            return (
+                jsonify({"error": ", ".join(error) + " parameter(s) is required"}),
+                400,
+            )
 
         logo_filename = DEFAULT_LOGO
         if "logo" in request.files:
@@ -243,31 +247,42 @@ def experience_by_index(index):
 
 @app.route("/resume/education", methods=["GET", "POST"])
 def education():
-    '''
+    """
     Handles education requests
-    '''
-    if request.method == 'GET':
-        return jsonify(data['education']), 200
+    """
+    if request.method == "GET":
+        return jsonify(data["education"]), 200
 
-    if request.method == 'POST':
+    if request.method == "POST":
         if not request.is_json:
-            return jsonify({'error': 'Request must be JSON'}), 400
+            return jsonify({"error": "Request must be JSON"}), 400
 
-        required_fields = ['course', 'school', 'start_date', 'end_date', 'grade', 'logo']
+        required_fields = [
+            "course",
+            "school",
+            "start_date",
+            "end_date",
+            "grade",
+            "logo",
+        ]
         missing_fields = validate_fields(required_fields, request.json)
 
         if missing_fields:
-            return jsonify({'error': f'Missing required fields: {", ".join(missing_fields)}'}), 400
+            return (
+                jsonify(
+                    {"error": f'Missing required fields: {", ".join(missing_fields)}'}
+                ),
+                400,
+            )
 
         new_education = Education(**request.json)
-        data['education'].append(new_education)
-        new_education_index = len(data['education']) - 1
+        data["education"].append(new_education)
+        new_education_index = len(data["education"]) - 1
 
-        return jsonify({
-            'id': new_education_index
-        }), 201
+        return jsonify({"id": new_education_index}), 201
 
     return jsonify({})
+
 
 @app.route("/resume/education/<int:index>", methods=["GET"])
 def education_by_index(index=None):
@@ -276,10 +291,10 @@ def education_by_index(index=None):
     - GET:
         - Returns a specific experience entry if a valid `index` is provided.
         - If the `index` is invalid, returns a 404 error.
-    
+
     - PUT:
         - Updates an existing experience entry.
-        - Validates the required fields 
+        - Validates the required fields
           (`title`, `company`, `start_date`, `end_date`, `description`)
           and ensures they are present and of the correct type.
         - If any fields are missing or invalid, returns a 400 error.
@@ -306,11 +321,15 @@ def education_by_index(index=None):
         if not request_body:
             return jsonify({"error": "Request must be JSON or include form data"}), 400
 
-        error = validate_fields(["title", "company", "start_date", "end_date", "description"],
-                                 request_body)
+        error = validate_fields(
+            ["title", "company", "start_date", "end_date", "description"], request_body
+        )
 
         if error:
-            return jsonify({"error": ", ".join(error) + " parameter(s) is required"}), 400
+            return (
+                jsonify({"error": ", ".join(error) + " parameter(s) is required"}),
+                400,
+            )
 
         logo_filename = DEFAULT_LOGO
         if "logo" in request.files:
@@ -332,18 +351,22 @@ def education_by_index(index=None):
         return jsonify({"message": "Experience updated", "id": index}), 204
     return jsonify({}), 400
 
+
 @app.route("/resume/education/<int:index>", methods=["DELETE"])
 def delete_education(index):
     """
     Delete an education entry by its index
-    
+
     :param index: The index of the education to delete
     """
     if 0 <= index < len(data["education"]):
         removed_education = data["education"].pop(index)
-        logging.info("Education deleted: %s at index %d", removed_education.course, index)
+        logging.info(
+            "Education deleted: %s at index %d", removed_education.course, index
+        )
         return jsonify({"message": "Education entry successfully deleted"}), 200
     return jsonify({"error": "Education entry not found"}), 404
+
 
 # pylint: disable=inconsistent-return-statements
 @app.route("/resume/skill", methods=["GET", "POST"])
@@ -351,20 +374,21 @@ def skill():
     """
     Handle skill requests
     """
-    if request.method == 'GET':
-        skill_id = request.args.get('id')
+    if request.method == "GET":
+        skill_id = request.args.get("id")
         if skill_id is None:
-            return jsonify(data['skill']), 200
+            return jsonify(data["skill"]), 200
         try:
             skill_id = int(skill_id)
         except ValueError:
-            return jsonify({'error': 'Invalid request'}), 400
-        if 0 <= skill_id < len(data['skill']):
-            return jsonify(data['skill'][skill_id]), 200
+            return jsonify({"error": "Invalid request"}), 400
+        if 0 <= skill_id < len(data["skill"]):
+            return jsonify(data["skill"][skill_id]), 200
 
     if request.method == "POST":
         request_body = (
-            request.form if request.content_type == "multipart/form-data"
+            request.form
+            if request.content_type == "multipart/form-data"
             else request.get_json()
         )
         if not request_body:
@@ -380,11 +404,13 @@ def skill():
 
         if missing_fields or invalid_fields:
             return (
-                jsonify({
-                    "error": "Validation failed",
-                    "missing_fields": missing_fields,
-                    "invalid_fields": invalid_fields
-                }),
+                jsonify(
+                    {
+                        "error": "Validation failed",
+                        "missing_fields": missing_fields,
+                        "invalid_fields": invalid_fields,
+                    }
+                ),
                 400,
             )
 
@@ -399,18 +425,13 @@ def skill():
 
         # Create new skill
         new_skill = Skill(
-            request_body["name"],
-            request_body["proficiency"],
-            logo_filename
+            request_body["name"], request_body["proficiency"], logo_filename
         )
         data["skill"].append(new_skill)
         logging.info("New skill added: %s", new_skill.name)
 
         return (
-            jsonify({
-                "message": "New skill created",
-                "id": len(data["skill"]) - 1
-            }),
+            jsonify({"message": "New skill created", "id": len(data["skill"]) - 1}),
             201,
         )
 
@@ -429,30 +450,27 @@ def user_information():
         if not request_data:
             return jsonify({"error": "Request must be JSON"}), 400
 
-        error = validate_fields(
-            ["name", "email_address", "phone_number"], request_data
-        )
+        error = validate_fields(["name", "email_address", "phone_number"], request_data)
         if error:
             return (
                 jsonify({"error": f"{', '.join(error)} parameter(s) is required"}),
                 400,
             )
 
-        is_valid_phone_number = validate_phone_number(
-            request_data["phone_number"]
-        )
+        is_valid_phone_number = validate_phone_number(request_data["phone_number"])
         if not is_valid_phone_number:
             return jsonify({"error": "Invalid phone number"}), 400
 
         data["user_information"] = request_data
-        logging.info("User information updated for: %s", request_data['name'])
+        logging.info("User information updated for: %s", request_data["name"])
         return jsonify(data["user_information"]), 201
+
 
 @app.route("/resume/skill/<int:skill_index>", methods=["DELETE"])
 def delete_skill(skill_index):
     """
     Delete a skill by its index.
-    
+
     :param skill_index: The index of the skill to delete.
     """
     if 0 <= skill_index < len(data["skill"]):
@@ -462,8 +480,39 @@ def delete_skill(skill_index):
     return jsonify({"error": "Skill not found"}), 404
 
 
+data["custom_sections"] = []
 
 
+@app.route("/custom-section", methods=["POST"])
+def add_custom_section():
+    """
+    Add a new custom section to the resume.
+    Requires a title and content in the request body.
+    """
+    request_data = request.get_json()
+    if not request_data:
+        return jsonify({"error": "Request must be JSON"}), 400
+
+    title = request_data.get("title")
+    content = request_data.get("content")
+
+    if not title or not content:
+        return jsonify({"error": "Both 'title' and 'content' are required"}), 400
+
+    new_section = {"title": title, "content": content}
+    data["custom_sections"].append(new_section)
+
+    section_id = len(data["custom_sections"]) - 1
+    logging.info("New custom section added: %s", title)
+    return jsonify({"message": "Custom section added", "id": section_id}), 201
+
+
+@app.route("/custom-sections", methods=["GET"])
+def get_custom_sections():
+    """
+    Retrieve all custom sections added by the user.
+    """
+    return jsonify(data["custom_sections"]), 200
 
 
 if __name__ == "__main__":
@@ -471,9 +520,10 @@ if __name__ == "__main__":
         os.makedirs(UPLOAD_FOLDER)
     app.run(debug=True)
 
-@app.route('/uploads/<path:filename>')
+
+@app.route("/uploads/<path:filename>")
 def uploaded_file(filename):
     """
     Function for serving uploaded files from /uploads.
     """
-    return send_from_directory(app.config['UPLOAD_FOLDER'], filename)
+    return send_from_directory(app.config["UPLOAD_FOLDER"], filename)

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -1,186 +1,203 @@
-'''
+"""
 Tests in Pytest
-'''
+"""
+
 from app import app
 from helpers import validate_fields, validate_phone_number
 
 
 def test_client():
-    '''
+    """
     Makes a request and checks the message received is the same
-    '''
-    response = app.test_client().get('/test')
+    """
+    response = app.test_client().get("/test")
     assert response.status_code == 200
-    assert response.json['message'] == "Hello, World!"
+    assert response.json["message"] == "Hello, World!"
 
 
 def test_experience():
-    '''
-    Add a new experience and then get all experiences. 
+    """
+    Add a new experience and then get all experiences.
 
     Check that it returns the new experience in that list
-    '''
+    """
     example_experience = {
         "title": "Software Developer",
         "company": "A Cooler Company",
         "start_date": "October 2022",
         "end_date": "Present",
         "description": "Writing JavaScript Code",
-        "logo": "default.jpg"
+        "logo": "default.jpg",
     }
 
-    item_id = app.test_client().post('/resume/experience',
-                                     json=example_experience).json['id']
-    response = app.test_client().get('/resume/experience')
+    item_id = (
+        app.test_client().post("/resume/experience", json=example_experience).json["id"]
+    )
+    response = app.test_client().get("/resume/experience")
     assert response.json[item_id] == example_experience
 
 
 def test_education():
-    '''
-    Add a new education and then get all educations. 
+    """
+    Add a new education and then get all educations.
 
     Check that it returns the new education in that list
-    '''
+    """
     example_education = {
         "course": "Engineering",
         "school": "NYU",
         "start_date": "October 2022",
         "end_date": "August 2024",
         "grade": "86%",
-        "logo": "default.jpg"
+        "logo": "default.jpg",
     }
 
-    item_id = app.test_client().post('/resume/education',
-                                     json=example_education).json['id']
+    item_id = (
+        app.test_client().post("/resume/education", json=example_education).json["id"]
+    )
 
-    response = app.test_client().get('/resume/education')
+    response = app.test_client().get("/resume/education")
     assert response.json[item_id] == example_education
+
 
 def test_delete_education():
     """
     Test the education deletion endpoint
     """
     # Ensure there's at least one education entry to delete
-    get_response = app.test_client().get('/resume/education')
+    get_response = app.test_client().get("/resume/education")
     assert get_response.status_code == 200
     initial_education_count = len(get_response.json)
 
     # Delete the last education entry
     last_index = initial_education_count - 1
-    response = app.test_client().delete(f'/resume/education/{last_index}')
+    response = app.test_client().delete(f"/resume/education/{last_index}")
     assert response.status_code == 200
     assert response.json["message"] == "Education entry successfully deleted"
 
     # Verify that the education entry count has decreased by one
-    get_response_after_delete = app.test_client().get('/resume/education')
+    get_response_after_delete = app.test_client().get("/resume/education")
     assert get_response_after_delete.status_code == 200
     assert len(get_response_after_delete.json) == initial_education_count - 1
 
     # Attempt to delete twice the same education entry
-    response = app.test_client().delete(f'/resume/education/{last_index}')
+    response = app.test_client().delete(f"/resume/education/{last_index}")
     assert response.status_code == 404
     assert response.json["error"] == "Education entry not found"
 
     # Attempt to delete an education entry with the out of range index
     invalid_index = initial_education_count + 1
-    response = app.test_client().delete(f'/resume/education/{invalid_index}')
+    response = app.test_client().delete(f"/resume/education/{invalid_index}")
     assert response.status_code == 404
     assert response.json["error"] == "Education entry not found"
 
 
 def test_skill():
-    '''
-    Add a new skill and then get all skills. 
+    """
+    Add a new skill and then get all skills.
 
     Check that it returns the new skill in that list
-    '''
+    """
 
     example_skill = {
         "name": "JavaScript",
         "proficiency": "2-4 years",
-        "logo": "default.jpg"
+        "logo": "default.jpg",
     }
 
-    item_id = app.test_client().post('/resume/skill',
-                                     json=example_skill).json['id']
+    item_id = app.test_client().post("/resume/skill", json=example_skill).json["id"]
 
-    response = app.test_client().get('/resume/skill')
+    response = app.test_client().get("/resume/skill")
     assert response.json[item_id] == example_skill
 
 
 def test_post_user_information():
-    '''
+    """
     Test the POST request for user information.
     It should allow setting user information and return status code 201.
-    '''
+    """
     new_user_info = {
         "name": "John Doe",
         "email_address": "john@example.com",
-        "phone_number": "+237680162416"
-
+        "phone_number": "+237680162416",
     }
-    response = app.test_client().post('/resume/user_information', json=new_user_info)
+    response = app.test_client().post("/resume/user_information", json=new_user_info)
     assert response.status_code == 201
-    assert response.json['name'] == new_user_info['name']
-    assert response.json['email_address'] == new_user_info['email_address']
-    assert response.json['phone_number'] == new_user_info['phone_number']
+    assert response.json["name"] == new_user_info["name"]
+    assert response.json["email_address"] == new_user_info["email_address"]
+    assert response.json["phone_number"] == new_user_info["phone_number"]
 
 
 def test_validate_fields_all_present():
-    '''
+    """
     Expect no missing fields
-    '''
+    """
     request_data = {
         "name": "John Doe",
         "email_address": "john@example.com",
-        "phone_number": "+123456789"
+        "phone_number": "+123456789",
     }
 
-    result = validate_fields(
-        ["name", "email_address", "phone_number"], request_data)
+    result = validate_fields(["name", "email_address", "phone_number"], request_data)
 
     assert result == []
 
 
 def test_validate_fields_missing_field():
-    '''
+    """
     Expect 'phone_number' to be missing
-    '''
-    request_data = {
-        "name": "John Doe",
-        "email_address": "john@example.com"
-    }
+    """
+    request_data = {"name": "John Doe", "email_address": "john@example.com"}
 
-    result = validate_fields(
-        ["name", "email_address", "phone_number"], request_data)
+    result = validate_fields(["name", "email_address", "phone_number"], request_data)
 
     assert result == ["phone_number"]
 
 
 def test_valid_phone_number():
-    '''
+    """
     Test a valid properly internationalized phone number returns True.
-    '''
+    """
     valid_phone = "+14155552671"
     assert validate_phone_number(valid_phone) is True
 
 
 def test_invalid_phone_number():
-    '''
+    """
     Test an invalid phone number returns False.
-    '''
+    """
     invalid_phone = "123456"
     assert validate_phone_number(invalid_phone) is False
 
+
 def test_post_skill():
-    skill_id = 0
-    new_skill = {
-        'name': 'Python',
-        'proficiency': 'Intermediate',
-        'logo': 'default.jpg'
+    """
+    Test POST
+    """
+    new_skill = {"name": "Python", "proficiency": "Intermediate", "logo": "default.jpg"}
+    response = app.test_client().post("/resume/skill", json=new_skill)
+    assert response.status_code == 201
+    assert response.json["message"] == "New skill created"
+
+
+def test_add_custom_section():
+    """
+    Test the addition of a custom section to the resume.
+    """
+    example_section = {
+        "title": "Certifications",
+        "content": "AWS Certified Solutions Architect",
     }
-    response = app.test_client().put(f'/resume/skill?id={skill_id}', json=new_skill)
+
+    response = app.test_client().post("/custom-section", json=example_section)
+    assert response.status_code == 201
+    assert response.json["message"] == "Custom section added"
+
+
+def test_get_custom_sections():
+    """
+    Test retrieving all custom sections.
+    """
+    response = app.test_client().get("/custom-sections")
     assert response.status_code == 200
-    assert response.json['name'] == new_skill['name']
-    assert response.json['proficiency'] == new_skill['proficiency']
-    assert response.json['logo'] == new_skill['logo']
+    assert isinstance(response.json, list)


### PR DESCRIPTION
Closes #44 

Implements a new feature that allows users to create custom sections in their resumes. It includes the following endpoints:

- POST /custom-section: Add a new custom section by providing a title and content. Input validation ensures both fields are present.
- GET /custom-sections: Retrieve all custom sections added by the user.
- Includes unit tests to verify both the addition and retrieval of custom sections.