### PR TITLE
Added reorder for Experiences, Educations and Skills with PUT endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -168,9 +168,13 @@ def reorder_experience():
     if not isinstance(order, list):
         return jsonify({"error": "'order' parameter must be a list"}), 400
 
-    print(order, len(data["experience"]))
     if len(order) != len(data["experience"]):
         return jsonify({"error": "Invalid 'order' parameter"}), 400
+        
+    for i in order:
+        if i < 0 or i >= len(data["experience"]):
+            return jsonify({"error": "Invalid 'order' parameter"}), 400
+
 
     data["experience"] = [data["experience"][i] for i in order]
 
@@ -306,6 +310,10 @@ def reorder_education():
 
     if len(order) != len(data["education"]):
         return jsonify({"error": "Invalid 'order' parameter"}), 400
+    
+    for i in order:
+        if i < 0 or i >= len(data["education"]):
+            return jsonify({"error": "Invalid 'order' parameter"}), 400
 
     data["education"] = [data["education"][i] for i in order]
 
@@ -405,6 +413,10 @@ def reorder_skill():
 
     if len(order) != len(data["skill"]):
         return jsonify({"error": "Invalid 'order' parameter"}), 400
+    
+    for i in order:
+        if i < 0 or i >= len(data["skill"]):
+            return jsonify({"error": "Invalid 'order' parameter"}), 400
 
     data["skill"] = [data["skill"][i] for i in order]
 

--- a/app.py
+++ b/app.py
@@ -152,6 +152,31 @@ def experience():
     return jsonify({})
 
 
+@app.route("/resume/experience/reorder", methods=["PUT"])
+def reorder_experience():
+    """
+    Reorder the experience entries based on the provided list of indices.
+    """
+    request_data = request.get_json()
+    if not request_data:
+        return jsonify({"error": "Request must be JSON"}), 400
+
+    if "order" not in request_data:
+        return jsonify({"error": "Missing 'order' parameter"}), 400
+
+    order = request_data["order"]
+    if not isinstance(order, list):
+        return jsonify({"error": "'order' parameter must be a list"}), 400
+
+    print(order, len(data["experience"]))
+    if len(order) != len(data["experience"]):
+        return jsonify({"error": "Invalid 'order' parameter"}), 400
+
+    data["experience"] = [data["experience"][i] for i in order]
+
+    return jsonify({"message": "Experience reordered"}), 204
+
+
 @app.route("/resume/experience/<int:index>", methods=["GET", "PUT"])
 def experience_by_index(index):
     """
@@ -262,6 +287,31 @@ def education():
         logging.info("New education added: %s", new_education.course)
         return jsonify({"message": "New education created", "id": len(data['education']) - 1}), 201
 
+
+@app.route("/resume/education/reorder", methods=["PUT"])
+def reorder_education():
+    """
+    Reorder the education entries based on the provided list of indices.
+    """
+    request_data = request.get_json()
+    if not request_data:
+        return jsonify({"error": "Request must be JSON"}), 400
+
+    if "order" not in request_data:
+        return jsonify({"error": "Missing 'order' parameter"}), 400
+
+    order = request_data["order"]
+    if not isinstance(order, list):
+        return jsonify({"error": "'order' parameter must be a list"}), 400
+
+    if len(order) != len(data["education"]):
+        return jsonify({"error": "Invalid 'order' parameter"}), 400
+
+    data["education"] = [data["education"][i] for i in order]
+
+    return jsonify({"message": "Education reordered"}), 204
+
+
 @app.route("/resume/education/<int:edu_index>", methods=["GET"])
 def education_by_index(edu_index):
     if 0 <= edu_index < len(data["education"]):
@@ -335,6 +385,30 @@ def skill():
             }),
             201,
         )
+
+
+@app.route("/resume/skill/reorder", methods=["PUT"])
+def reorder_skill():
+    """
+    Reorder the skill entries based on the provided list of indices.
+    """
+    request_data = request.get_json()
+    if not request_data:
+        return jsonify({"error": "Request must be JSON"}), 400
+
+    if "order" not in request_data:
+        return jsonify({"error": "Missing 'order' parameter"}), 400
+
+    order = request_data["order"]
+    if not isinstance(order, list):
+        return jsonify({"error": "'order' parameter must be a list"}), 400
+
+    if len(order) != len(data["skill"]):
+        return jsonify({"error": "Invalid 'order' parameter"}), 400
+
+    data["skill"] = [data["skill"][i] for i in order]
+
+    return jsonify({"message": "Skill reordered"}), 204
 
 
 @app.route("/resume/user_information", methods=["GET", "POST", "PUT"])

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -1,6 +1,7 @@
 import pytest
-from app import app
+from app import app, data
 from helpers import validate_fields, validate_phone_number
+import random
 
 @pytest.fixture
 def client():
@@ -163,4 +164,52 @@ def test_upgrade_experience():
         "logo": "default.jpg"
     }
     response = app.test_client().put('/resume/experience/0', json=new_example_experience)
+    assert response.status_code == 204
+
+def test_reorder_experience():
+    '''
+    Test the reorder experience endpoint for experience ID bounds checking.
+    Reorders the only experience and check if the reorder was successful.
+    '''
+    # Test some invalid experience indices
+    response = app.test_client().put(f'/resume/experience/reorder', json={"order": [0, 1, 2]})
+    assert response.status_code == 400
+
+    # shuffle the experience order of data['experience']
+    new_order = random.sample(range(len(data['experience'])), len(data['experience']))
+
+    # Reorder the only experience.
+    response = app.test_client().put('/resume/experience/reorder', json={"order": new_order})
+    assert response.status_code == 204
+
+def test_reorder_education():
+    '''
+    Test the reorder education endpoint for education ID bounds checking.
+    Reorders the only education and check if the reorder was successful.
+    '''
+    # Test some invalid education indices
+    response = app.test_client().put(f'/resume/education/reorder', json={"order": [0, 1, 2]})
+    assert response.status_code == 400
+
+    # shuffle the education order of data['education']
+    new_order = random.sample(range(len(data['education'])), len(data['education']))
+
+    # Reorder the only education.
+    response = app.test_client().put('/resume/education/reorder', json={"order": new_order})
+    assert response.status_code == 204
+
+def test_reorder_skill():
+    '''
+    Test the reorder skill endpoint for skill ID bounds checking.
+    Reorders the only skill and check if the reorder was successful.
+    '''
+    # Test some invalid skill indices
+    response = app.test_client().put(f'/resume/skill/reorder', json={"order": [0, 1, 2]})
+    assert response.status_code == 400
+
+    # shuffle the skill order of data['skill']
+    new_order = random.sample(range(len(data['skill'])), len(data['skill']))
+
+    # Reorder the only skill.
+    response = app.test_client().put('/resume/skill/reorder', json={"order": new_order})
     assert response.status_code == 204


### PR DESCRIPTION
### Pull Request: Added Reorder Functionality for Experiences, Education, and Skills

#### Summary:
Added three new PUT endpoints to support reordering of resume sections:

- `PUT /resume/experience/reorder`
- `PUT /resume/education/reorder`
- `PUT /resume/skill/reorder`