### PR TITLE
Implement DELETE Endpoint for Experience Entries

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,6 +149,17 @@ def experience():
         return jsonify({"message": "New experience created", "id": len(data["experience"]) - 1}), 201
 
 
+@app.route("/resume/experience/<int:index>", methods=["DELETE"])
+def delete_experience(index):
+    """
+    Delete experience entry by index
+    """
+    if 0 <= index < len(data["experience"]):
+        data["experience"].pop(index)
+        return jsonify({"message": "Experience successfully deleted"}), 200
+    return jsonify({"error": "Experience not found"}), 404
+
+
 @app.route("/resume/education", methods=["GET", "POST"])
 def education():
     """

--- a/app.py
+++ b/app.py
@@ -156,8 +156,8 @@ def delete_experience(index):
     """
     if 0 <= index < len(data["experience"]):
         data["experience"].pop(index)
-        return jsonify({"message": "Experience successfully deleted"}), 200
-    return jsonify({"error": "Experience not found"}), 404
+        return jsonify({"message": "Experience entry successfully deleted"}), 200
+    return jsonify({"error": "Experience entry not found"}), 404
 
 
 @app.route("/resume/education", methods=["GET", "POST"])

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -71,6 +71,30 @@ def test_experience(client):
     response = client.get("/resume/experience")
     assert response.json[item_id] == example_experience
 
+def test_delete_experience(client):
+    """Test the experience deletion endpoint."""
+    get_response = client.get("/resume/experience")
+    assert get_response.status_code == 200
+    initial_experience_count = len(get_response.json)
+
+    last_index = initial_experience_count - 1
+    response = client.delete(f"/resume/experience/{last_index}")
+    assert response.status_code == 200
+    assert response.json["message"] == "Experience entry successfully deleted"
+
+    get_response_after_delete = client.get("/resume/experience")
+    assert get_response_after_delete.status_code == 200
+    assert len(get_response_after_delete.json) == initial_experience_count - 1
+
+    response = client.delete(f"/resume/experience/{last_index}")
+    assert response.status_code == 404
+    assert response.json["error"] == "Experience entry not found"
+
+    invalid_index = initial_experience_count + 1
+    response = client.delete(f"/resume/experience/{invalid_index}")
+    assert response.status_code == 404
+    assert response.json["error"] == "Experience entry not found"
+
 
 def test_education(client):
     """Add a new education and check if it's returned in the list."""


### PR DESCRIPTION
This pull request adds a new DELETE functionality to the resume management API, allowing users to delete an existing experience entry by its index.

A test case has been included to ensure the successful entry deletion and edge cases such as attempting to delete an out of bounds entry.

Closes #5 